### PR TITLE
feat: Simple Movie Page

### DIFF
--- a/backend/src/resolvers/movie.ts
+++ b/backend/src/resolvers/movie.ts
@@ -65,13 +65,15 @@ export class MovieResolver {
   ): Promise<PaginatedMovies> {
     const realLimit = Math.min(50, limit);
 
-    const movies = await AppDataSource.getRepository(Movie)
+    const movieRepository = AppDataSource.getRepository(Movie);
+
+    const movies = await movieRepository
       .createQueryBuilder('movie')
       .skip(skip ?? 0)
       .take(limit)
       .getMany();
 
-    const movieCount = await AppDataSource.getRepository(Movie)
+    const movieCount = await movieRepository
       .createQueryBuilder('movie')
       .getCount();
 

--- a/frontend/src/app/movie/[id]/page.tsx
+++ b/frontend/src/app/movie/[id]/page.tsx
@@ -2,7 +2,8 @@
 
 import { AppHeader } from '@/components/AppHeader';
 import { useGetId } from '@/hooks/useGetId';
-import { Card } from '@mui/material';
+import { useGetMovieData } from '@/hooks/useGetMovieData';
+import { Card, CardContent, Typography } from '@mui/material';
 
 interface MovieProps {
   id: string;
@@ -10,9 +11,22 @@ interface MovieProps {
 
 const Movie: React.FC<MovieProps> = ({}) => {
   const id = useGetId();
+  const { data, loading, error } = useGetMovieData(id);
   return (
     <AppHeader>
-      <Card>{id} Test Page</Card>
+      {loading && <p>Loading...</p>}
+      {error && <p>{error.message}</p>}
+      {data && (
+        <Card>
+          <CardContent>
+            <Typography>id: {data.id}</Typography>
+            <Typography>title: {data.title}</Typography>
+            <Typography>overview: {data.overview}</Typography>
+            <Typography>release_date: {data.release_date}</Typography>
+            <Typography>run_time: {data.run_time}</Typography>
+          </CardContent>
+        </Card>
+      )}
     </AppHeader>
   );
 };

--- a/frontend/src/hooks/useGetId.ts
+++ b/frontend/src/hooks/useGetId.ts
@@ -3,5 +3,5 @@
 import { useParams } from 'next/navigation';
 
 export const useGetId = () => {
-  return useParams<{ id: string }>().id;
+  return parseInt(useParams<{ id: string }>().id);
 };

--- a/frontend/src/hooks/useGetMovieData.ts
+++ b/frontend/src/hooks/useGetMovieData.ts
@@ -1,0 +1,44 @@
+import { useMovieQuery } from '@/generated/types';
+import { HookResult, Movie } from '@/types/types';
+import { useEffect, useState } from 'react';
+
+export const useGetMovieData = (id: number): HookResult<Movie> => {
+  const [state, setState] = useState<HookResult<Movie>>({
+    data: null,
+    loading: true,
+    error: null,
+  });
+
+  const {
+    data: movieData,
+    loading: movieLoading,
+    error: movieError,
+  } = useMovieQuery({ variables: { id } });
+
+  useEffect(() => {
+    if (movieLoading) {
+      setState({ loading: true });
+    }
+
+    if (movieData) {
+      // setState({ data: movieData, loading: false });
+      const movie = movieData.movie;
+      setState({
+        data: {
+          id: movie?.id ?? '',
+          title: movie?.title ?? '',
+          overview: movie?.overview ?? '',
+          release_date: movie?.release_date ?? '',
+          run_time: movie?.runtime ?? 0,
+        },
+        loading: false,
+      });
+    }
+
+    if (movieError) {
+      setState({ data: null, loading: false, error: movieError });
+    }
+  }, [movieData, movieError, movieLoading]);
+
+  return state;
+};

--- a/frontend/src/hooks/useGetMoviesData.ts
+++ b/frontend/src/hooks/useGetMoviesData.ts
@@ -1,25 +1,17 @@
 import { useMoviesQuery } from '@/generated/types';
-import { HookResult } from '@/types/types';
+import { HookResult, Movie } from '@/types/types';
 import { useEffect, useState } from 'react';
 
-interface MovieResponse {
+interface MoviesResponse {
   count: number;
   movies: Movie[];
-}
-
-interface Movie {
-  id: string;
-  title: string;
-  overview: string;
-  release_date: string;
-  run_time: number;
 }
 
 export const useGetMoviesData = (
   limit: number,
   skip: number
-): HookResult<MovieResponse> => {
-  const [state, setState] = useState<HookResult<MovieResponse>>({
+): HookResult<MoviesResponse> => {
+  const [state, setState] = useState<HookResult<MoviesResponse>>({
     data: null,
     loading: true,
     error: null,

--- a/frontend/src/types/types.ts
+++ b/frontend/src/types/types.ts
@@ -5,3 +5,11 @@ export interface HookResult<T> {
   loading: boolean;
   error?: ApolloError | null;
 }
+
+export interface Movie {
+  id: string;
+  title: string;
+  overview: string;
+  release_date: string;
+  run_time: number;
+}


### PR DESCRIPTION
## Changes
- Updated `useGetId` to infer return type as a number.
- Updated the Page to display the movie information such as the `id`, `title`,`overview`,`release_date`, and `run_time`.
- Moved `Movie` interface into `types` directory and file as used in multiple places.
- Updated `useGetMoviesData` with the appropriate interface name.
- Created new `useGetMovieData` hook that gets passed in an `id` and makes the appropriate GraphQL API call to get the movie instance.
- Updated `MovieResolver` to have a reference to the repository and re-use.